### PR TITLE
Depend on either telnet or telnet-client to allow usage of telnet-ssl

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.8.4
 Package: fence-agents-pve
 Architecture: any
 Depends: ${perl:Depends}, ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}, openipmi, sg3-utils, python-pexpect, python-pycurl,
- libnet-snmp-perl, libnet-telnet-perl, snmp, telnet, openssh-client,
+ libnet-snmp-perl, libnet-telnet-perl, snmp, telnet | telnet-client, openssh-client,
  python-openssl, python-suds
 Description: fence agents for redhat cluster suite
  This package provides various fence agents.


### PR DESCRIPTION
Otherwise fence-agents-pve is uninstallable on systems which
depend on e.g. telnet-ssl, and telnet-client is provided by
telnet as well as telnet-ssl:

| % apt-cache show telnet telnet-ssl | grep Provides
| Provides: telnet-client
| Provides: telnet-client

Closes: https://bugzilla.proxmox.com/show_bug.cgi?id=412
Signed-off-by: Michael Prokop mika@grml.org
